### PR TITLE
Fixed links to instructor training and handbook

### DIFF
--- a/_episodes/05-week_5_discussion_questions.md
+++ b/_episodes/05-week_5_discussion_questions.md
@@ -1,18 +1,19 @@
----	
-title: "Week 5 Discussion Questions"	
-teaching: 0	
-exercises: 0	
-questions:	
-- "Key question"	
-objectives:	
-- "First objective."	
-keypoints:	
-- "First key point."	
+--- 
+title: "Week 5 Discussion Questions"    
+teaching: 0 
+exercises: 0    
+questions:  
+- "Key question"    
+objectives: 
+- "First objective."    
+keypoints:  
+- "First key point."    
 ---
 ## Reading:
 [Welcome](https://carpentries.github.io/instructor-training/01-welcome/)  
-[How Learning Works: The Importance of Practice](https://carpentries.github.io/instructor-training/02-practice-learning/)  
-[How Learning Works: Expertise and Instruction](https://carpentries.github.io/instructor-training/03-expertise/)
+[Instructor Training: Building Skill With Practice
+](https://carpentries.github.io/instructor-training/02-practice-learning/)  
+[Instructor Training: Expertise and Instruction](https://carpentries.github.io/instructor-training/03-expertise/)
 
 ## Hypothes.is: 
 1\. (Optional) Write comments, questions, or replies on the curriculum readings for today. Be sure you are using our private Hypothes.is group when you add your comments. 
@@ -29,7 +30,7 @@ keypoints:
 
 #### [How Learning Works: The Importance of Practice](https://carpentries.github.io/instructor-training/02-practice-learning/) 
 
-4\. It can be useful to prepare personal examples for some topics. Identify one thing each that you’re a novice for, a competent practitioner for and an expert at. How would you explain the way you have categorized these skills?
+4\. It can be useful to prepare personal examples for some topics. Identify one thing each that you're a novice for, a competent practitioner for and an expert at. How would you explain the way you have categorized these skills?
 
 5\. Try creating a concept map that relates the following 3 concepts: 
 - skill acquisition

--- a/_episodes/06-Week_6_discussion_questions.md
+++ b/_episodes/06-Week_6_discussion_questions.md
@@ -1,19 +1,19 @@
----	
-title: "Week 6 Discussion Questions"	
-teaching: 0	
-exercises: 0	
-questions:	
-- "Key question"	
-objectives:	
-- "First objective."	
-keypoints:	
-- "First key point."	
+--- 
+title: "Week 6 Discussion Questions"    
+teaching: 0 
+exercises: 0    
+questions:  
+- "Key question"    
+objectives: 
+- "First objective."    
+keypoints:  
+- "First key point."    
 ---
 ## Reading: 
-[How Learning Works: Working Memory and Cognitive Load](https://carpentries.github.io/instructor-training/05-memory/index.html)  
-[Building Teaching Skill: Getting Feedback](https://carpentries.github.io/instructor-training/06-feedback/index.html)  
-[Creating a Positive Learning Environment: Motivation and Demotivation](https://carpentries.github.io/instructor-training/08-motivation/index.html)  
-[Creating a Positive Learning Environment: Mindset](https://carpentries.github.io/instructor-training/09-mindset/index.html)
+[Instructor Training: Memory and Cognitive Load](https://carpentries.github.io/instructor-training/05-memory/index.html)  
+[Instructor Training: Building Skill With Feedback](https://carpentries.github.io/instructor-training/06-feedback/index.html)  
+[Instructor Training: Motivation and Demotivation](https://carpentries.github.io/instructor-training/08-motivation/index.html)  
+[Instructor Training: Mindset](https://carpentries.github.io/instructor-training/09-mindset/index.html)
 
 ## Hypothes.is: 
 1\. Please write at least one comment or reply to a comment on each module. Wherever possible, try to connect content to material covered in the book (page numbers are be great if you can find them!). Other comments might include questions, identification of key points, or thoughts on how learners might interpret (or misinterpret) certain content.
@@ -22,7 +22,7 @@ keypoints:
 
 ### Instructor Training Curriculum
 #### [How Learning Works: Working Memory and Cognitive Load](https://carpentries.github.io/instructor-training/05-memory/index.html)
-2\. This episode provides reasons why we go slowly and allow emphasize practice. However, instructors are often faced with the urge to go faster or cover more. How can we help instructors remember to keep it slow and resist the urge to “cover” more material?
+2\. This episode provides reasons why we go slowly and allow emphasize practice. However, instructors are often faced with the urge to go faster or cover more. How can we help instructors remember to keep it slow and resist the urge to "cover" more material?
 
 3\. The concept mapping example in this exercise is often difficult for Trainers and learners to navigate. Can you construct an alternative example that is more accessible to novices but still has some relevance to our curriculum?
 

--- a/_episodes/07-Week_7_discussion_questions.md
+++ b/_episodes/07-Week_7_discussion_questions.md
@@ -1,23 +1,23 @@
----	
-title: "Week 7 Discussion Questions"	
-teaching: 0	
-exercises: 0	
-questions:	
-- "Key question"	
-objectives:	
-- "First objective."	
-keypoints:	
-- "First key point."	
+--- 
+title: "Week 7 Discussion Questions"    
+teaching: 0 
+exercises: 0    
+questions:  
+- "Key question"    
+objectives: 
+- "First objective."    
+keypoints:  
+- "First key point."    
 ---
 
 ## Reading
-[Building Teaching Skill: The Importance of Practice](https://carpentries.github.io/instructor-training/11-practice-teaching/index.html)  
-[Wrap-up and Homework](https://carpentries.github.io/instructor-training/12-homework/index.html)  
-[Welcome Back](http://carpentries.github.io/instructor-training/13-second-welcome/index.html)   
-[Building Teaching Skill: Lesson Study](https://carpentries.github.io/instructor-training/14-lesson-study/index.html)  
-[Building Teaching Skill: Live Coding](https://carpentries.github.io/instructor-training/15-live/index.html)  
-[Building Teaching Skill: Performance Revised](http://carpentries.github.io/instructor-training/17-performance/index.html)
-[The Carpentries: Workshop Introductions](https://carpentries.github.io/instructor-training/19-introductions/index.html)
+[Instructor Training: Teaching is a Skill](https://carpentries.github.io/instructor-training/11-practice-teaching/index.html)  
+[Instructor Training: Wrap-up and Homework](https://carpentries.github.io/instructor-training/12-homework/index.html)  
+[Instructor Training: Welcome Back](http://carpentries.github.io/instructor-training/13-second-welcome/index.html)   
+[Instructor Training: Live Coding is a Skill](https://carpentries.github.io/instructor-training/14-live/index.html)  
+[Instructor Training: Preaparing to Teach](https://carpentries.github.io/instructor-training/15-lesson-study/index.html)  
+[Instructor Training: More Practice Live Coding](http://carpentries.github.io/instructor-training/17-performance/index.html)
+[Instructor Training: Managing a Diverse Classroom](https://carpentries.github.io/instructor-training/18-management/index.html)
 
 ## Hypothes.is: 
 1\. Please write at least one comment or reply to a comment on each module. Wherever possible, try to connect content to material covered in the book (page numbers are be great if you can find them!). Other comments might include questions, identification of key points, or thoughts on how learners might interpret (or misinterpret) certain content.
@@ -29,7 +29,7 @@ keypoints:
 2\. The majority of this lesson consists of practice and feedback in various ways. Apart from those experiences, can you identify two key points that you would like to get across to learners during this lesson?
 
 #### [Building Teaching Skill: Lesson Study](https://carpentries.github.io/instructor-training/14-lesson-study/index.html)
-3\. This module addresses some new points and also some points that we began to discuss in previous lessons. How does the discussion of “challenge” exercises fit here in the context of lesson study? How could this lesson be improved?
+3\. This module addresses some new points and also some points that we began to discuss in previous lessons. How does the discussion of "challenge" exercises fit here in the context of lesson study? How could this lesson be improved?
 
 #### [Building Teaching Skill: Live Coding](https://carpentries.github.io/instructor-training/15-live/index.html)
 4\. How does the Carpentry practice of live coding connect to things we have read in How Learning Works?

--- a/_episodes/08-Week_8_discussion_questions.md
+++ b/_episodes/08-Week_8_discussion_questions.md
@@ -1,13 +1,13 @@
----	
-title: "Week 8 Discussion Questions"	
-teaching: 0	
-exercises: 0	
-questions:	
-- "Key question"	
-objectives:	
-- "First objective."	
-keypoints:	
-- "First key point."	
+--- 
+title: "Week 8 Discussion Questions"    
+teaching: 0 
+exercises: 0    
+questions:  
+- "Key question"    
+objectives: 
+- "First objective."    
+keypoints:  
+- "First key point."    
 ---
 
 # Trainer Training Book Club Week 8
@@ -17,10 +17,11 @@ keypoints:
 
 ## Reading:
 _How Learning Works_: Conclusion  
-[The Carpentries: How We Operate](https://carpentries.github.io/instructor-training/20-carpentries/index.html)  
-[The Carpentries: Teaching Practices](https://carpentries.github.io/instructor-training/22-practices/index.html)  
-[Afternoon Wrap-Up](https://carpentries.github.io/instructor-training/23-checkout/index.html)  
-[Operations Guide](https://software-carpentry.org/workshops/operations/index.html)  
+[Instructor Training: Checkout Process](https://carpentries.github.io/instructor-training/20-checkout/index.html)  
+[Instructor Training: The Carpentries: How We Operate](https://carpentries.github.io/instructor-training/21-carpentries/index.html)  
+[Instructor Training: Workshop Introductions](https://carpentries.github.io/instructor-training/23-introductions/index.html)  
+[Instructor Training: Putting It Together](https://carpentries.github.io/instructor-training/24-practices/index.html)  
+[The Carpentries Handbook: Teaching and Hosting](https://docs.carpentries.org/topic_folders/hosts_instructors/index.html)  
 [Pre-Workshop Reading: The Science of Learning](https://carpentries.github.io/instructor-training/files/papers/science-of-learning-2015.pdf)  
 Review [Trainer Guide](https://docs.carpentries.org/topic_folders/instructor_training/trainers_guide.html)
 
@@ -35,7 +36,7 @@ Review [Trainer Guide](https://docs.carpentries.org/topic_folders/instructor_tra
 
 #### Conclusion p. 217-224
 
-3\. What advice might you give to instructors to help them “play to their own strengths and weaknesses”? How might you advise instructors who identify as ‘introverts’ vs ‘extroverts’?
+3\. What advice might you give to instructors to help them "play to their own strengths and weaknesses"? How might you advise instructors who identify as 'introverts' vs 'extroverts'?
 
 ### Instructor Training Curriculum
 #### [The Carpentries: How We Operate](https://carpentries.github.io/instructor-training/20-carpentries/index.html)


### PR DESCRIPTION
The links on lessons 4..8 were to an earlier version of the instructor training. Lesson names have changed (and in lessons 7 and 8, some of the links were stale). I guessed that you want https://docs.carpentries.org/topic_folders/hosts_instructors/index.html to replace the ops handbook, and I removed the book title for the instructor lessons. Hopefully this will help reduce some confusion. (It also looks like sublime text did some whitespace and special character cleaning)
