### PR TITLE
Canonicalize CRAN links

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -4,9 +4,9 @@
 [email]: mailto:lessons@software-carpentry.org
 [contrib-covenant]: https://contributor-covenant.org/
 [contributing]: {{ site.github.repository_url }}/blob/gh-pages/CONTRIBUTING.md
-[cran-checkpoint]: https://cran.r-project.org/web/packages/checkpoint/index.html
-[cran-knitr]: https://cran.r-project.org/web/packages/knitr/index.html
-[cran-stringr]: https://cran.r-project.org/web/packages/stringr/index.html
+[cran-checkpoint]: https://cran.r-project.org/package=checkpoint
+[cran-knitr]: https://cran.r-project.org/package=knitr
+[cran-stringr]: https://cran.r-project.org/package=stringr
 [github-importer]: https://import.github.com/
 [importer]: https://github.com/new/import
 [jekyll-collection]: https://jekyllrb.com/docs/collections/


### PR DESCRIPTION
CRAN [asks people](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) to use this URL variant when linking to packages ;-) This PR results from a semi-automatic search-and-replace script and implements their suggestion.