### PR TITLE
Change syllabus page numbers to correspond to the listed chapters and appendices

### DIFF
--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -11,20 +11,20 @@
     <tr>
         <td><a href="https://carpentries.github.io/trainer-training/01-week1_discussion_questions/index.html">1</td>
         <td>Foreword, About the Authors, Introduction</td>
-        <td>xiii-xvi, xix-9; 10-39</td>
+        <td>xiii-xvi, xix-9</td>
         <td> <a href="https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html">Trainer Agreement</a>, <a href="https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html">Code of Conduct</a>, <a href="https://docs.carpentries.org/topic_folders/instructor_training/trainers_guide.html">Trainers Guide</a> (skim), <a href="http://carpentries.github.io/instructor-training/">Instructor Training Curriculum</a> (preview), <a href="https://github.com/carpentries/instructor-training">Instructor Training Curriculum Repository</a> (preview) 
 </td>
     </tr>
     <tr>
         <td><a href="https://carpentries.github.io/trainer-training/02_week2_discussion_questions/index.html">2</td>
-        <td>Chapter 1, Chapter 2, Appendix A, Appendix  B</td>
-        <td>40-65; 225-230; 66-90</td>
+        <td>Chapter 1, Chapter 2, Appendix A, Appendix B</td>
+        <td>10-65, 225-230</td>
         <td></td>
     </tr>
     <tr>
         <td><a href="https://carpentries.github.io/trainer-training/03_week3_discussion_questions/index.html">3</td>
         <td>Chapter 3, Chapter 4, Appendix D</td>
-        <td>91-120, 244-7,</td>
+        <td>66-120, 244-7</td>
         <td></td>
     </tr>
     <tr>
@@ -36,7 +36,7 @@
     <tr>
         <td><a href="https://carpentries.github.io/trainer-training/05-week_5_discussion_questions/index.html">5</td>
         <td>Chapter 6, Chapter 7</td>
-        <td>152-187, 188-216</td>
+        <td>153-216</td>
         <td><a href="https://web.hypothes.is/">Explore Hypothes.is as a commenting tool</td>
     </tr>
         <tr>


### PR DESCRIPTION
This PR changes the page numbers listed in the syllabus to correspond to the chapters and appendices listed in the same row.

Resolves #30