### PR TITLE
Standardise terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 # Curriculum for the Trainer Training Program
 
-Individuals who graduate from this program become Trainers with The Carpentries and are qualified to teach instructor training workshops.
+Individuals who graduate from this program become Trainers with The Carpentries and are qualified to teach Instructor Training courses.

--- a/_episodes/01-week1_discussion_questions.md
+++ b/_episodes/01-week1_discussion_questions.md
@@ -70,7 +70,7 @@ role as a Trainer! Do the 7 principles apply equally well to all of these contex
 
 # Overview of Trainer Training
 This program is an on-boarding course designed to support Carpentries community-members in preparing to teach Instructor
-Training workshops. It is not a substitute for Instructor Training; in contrast, this training includes fewer contact hours
+Training courses. It is not a substitute for Instructor Training; in contrast, this training includes fewer contact hours
 and more independent work time stretched over a 10 week period.
 
 Each participant brings a different skill set to this training. Most trainees have background in educational settings and/or
@@ -81,9 +81,9 @@ Trainer community after completing this training.
 > ## Trainer Checkout
 > In addition to attending weekly meetings, there are additional requirements for Trainer certification. These are:
 > - Observe a teaching demonstration session
-> - Observe (with option to participate) 4 hours of an Instructor Training workshop
+> - Observe (with option to participate) 4 hours of an Instructor Training course
 > - Trainees who are not certified Carpentries Instructors should complete Instructor certification concurrently. This
-> includes attending a full Instructor Training workshop as a learner if not yet attended. Attending a workshop or demo within
+> includes attending a full Instructor Training course as a learner if not yet attended. Attending a course or demo within
 > the training time frame can fulfill the above requirements for observation if requested.
 {: .discussion}
 
@@ -113,7 +113,7 @@ Most of our Instructor Training events are taught online, via Zoom. When circums
 person. All events must have a least 2 Trainers in attendance. New trainees should plan to be
 available for teaching assignments as soon as certification is complete. New Trainers will be matched with experienced
 Trainers whenever possible. New trainees are also welcome to request a role as a third trainer to reduce the teaching load
-and enhance observation opportunities during their first workshop.
+and enhance observation opportunities during their first training.
 
 
 ### The Trainer Community

--- a/_episodes/01-week1_discussion_questions.md
+++ b/_episodes/01-week1_discussion_questions.md
@@ -3,15 +3,15 @@ title: "Week 1 Discussion Questions"
 teaching: 30
 exercises: 30
 questions:
-- "What is involved in serving as a Carpentries Instructor Trainer?"
+- "What is involved in serving as a Carpentries Trainer?"
 - "What should you expect from this training?"
 objectives:
-- "Understand what is involved in being an Instructor Trainer."
+- "Understand what is involved in being a Trainer."
 - "Prepare to complete the steps for Trainer checkout."
 - "Predict what they will learn from reading _How Learning Works_."
 - "Recognize that teaching principles may apply differently to different training contexts within The Carpentries."
 keypoints:
-- "The Instructor Trainer role comes with powers and responsibilities. Some powers are limited to preserve sustainability of The Carpentries, but we will work with you to meet your goals as closely as possible."
+- "The Trainer role comes with powers and responsibilities. Some powers are limited to preserve sustainability of The Carpentries, but we will work with you to meet your goals as closely as possible."
 - "Teaching and learning are separate, though related, processes. And then there is learning to teach!"
 - "Most popular texts do not aim to onboard readers to engaging with primary literature in a field. This presents barriers to responsible engagement across disciplines, particularly in education."
 ---
@@ -23,7 +23,7 @@ keypoints:
 - Introduction
 
 Carpentries readings:
-- [Instructor Trainers](https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html)
+- [Trainers](https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html)
 - [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
 
 Preview to get a sense for what is contained in these lengthier references:
@@ -110,7 +110,7 @@ assigned to you, please let your host know immediately.
 
 ### Instructor Training Events (in brief)
 Most of our Instructor Training events are taught online, via Zoom. When circumstances permit, some partner institutions also host events in-
-person. All events must have a least 2 Instructor Trainers in attendance. New trainees should plan to be
+person. All events must have a least 2 Trainers in attendance. New trainees should plan to be
 available for teaching assignments as soon as certification is complete. New Trainers will be matched with experienced
 Trainers whenever possible. New trainees are also welcome to request a role as a third trainer to reduce the teaching load
 and enhance observation opportunities during their first workshop.
@@ -161,7 +161,7 @@ their other service activities in the community to compensate during their tenur
 
 
 ### A Culture of Contribution
-Instructor Trainers are a vital part of The Carpentries community. In addition to training Instructors and supporting the collaborative
+Trainers are a vital part of The Carpentries community. In addition to training Instructors and supporting the collaborative
 maintenance of our Instructor Training curriculum, Trainers typically take
 on leadership roles in their own communities, locally or globally. Many assume leadership within the Trainer community, but all
 are expected to contribute by coming to meetings and/or sharing thoughts or feedback in other ways. Whatever your plans,

--- a/_episodes/01-week1_discussion_questions.md
+++ b/_episodes/01-week1_discussion_questions.md
@@ -109,7 +109,7 @@ Your host will provide you with a proposed schedule for these roles for the full
 assigned to you, please let your host know immediately.
 
 ### Instructor Training Events (in brief)
-Most of our Instructor Training events are taught online, via Zoom. When circumstances permit, some partner institutions also host events in-
+Most of our Instructor Training events are taught online, via Zoom. When circumstances permit, some Member organisations also host events in-
 person. All events must have a least 2 Trainers in attendance. New trainees should plan to be
 available for teaching assignments as soon as certification is complete. New Trainers will be matched with experienced
 Trainers whenever possible. New trainees are also welcome to request a role as a third trainer to reduce the teaching load

--- a/_episodes/02_week2_discussion_questions.md
+++ b/_episodes/02_week2_discussion_questions.md
@@ -11,7 +11,7 @@ objectives:
 - "Evaluate the knowledge-organization strategies in terms of ease of use for new Instructors."
 - "Apply a concept map to explore concepts of teaching and learning." 
 keypoints:
-- "Prior knowledge about teaching strategies varies among trainees in Instructor Training workshops. Being attentive to this will improve your impact."
+- "Prior knowledge about teaching strategies varies among trainees in Instructor Training courses. Being attentive to this will improve your impact."
 - "Pre-assessment surveys are a critical component of all Carpentries workshops. Help us make them useful for you!"
 - "Carpentries curriculum templates provide some support for knowledge organization. Instructors can implement additional strategies to help learners create useful connections."
 - "Concept maps are a challenging, minimally structured task. They are useful for exploring concepts and relationships prior to teaching because they can make the organization of knowledge more explicit."

--- a/_episodes/02_week2_discussion_questions.md
+++ b/_episodes/02_week2_discussion_questions.md
@@ -42,7 +42,7 @@ could ask one additional question, what would it be?
 #### Chapter 2: How Does the Way Students Organize Knowledge Affect Their Learning
 
 4\. Examine Figure 2.2 (p.50 of the print edition). How do these diagrams relate to knowledge or learner mental models that 
-you are familiar with? Which do you think best represents a learner who has just taken a Carpentries technical workshop? 
+you are familiar with? Which do you think best represents a learner who has just taken a Carpentries workshop? 
 
 5\. Take a look at the strategies for ways Instructors can assess and enhance their own knowledge organization at the end of Chapter 2 (p. 59-65). Choose one strategy and think about how an Instructor could apply it when preparing to teach a Carpentries workshop. On a scale from 1-10, how challenging do you think it would be for a new Instructor to use?  
 

--- a/_episodes/03_week3_discussion_questions.md
+++ b/_episodes/03_week3_discussion_questions.md
@@ -7,9 +7,9 @@ objectives:
 - "Classify anticipated goals of learners as learning or performance-based."
 - "Assess the usefulness of different strategies related to motivation in Carpentries workshops and trainings."
 - "Predict the impact of cognitive limitations on both learners and Trainers in Instructor Training."
-- "Compare the challenge of preparing different types of learners (Instructor trainees vs. technical) to transfer skills to usable contexts."
+- "Compare the challenge of preparing different types of learners (Instructor trainees vs. workshop learners) to transfer skills to usable contexts."
 keypoints:
-- "Learner motivation in Instructor Training can be very different from the motivation we see in technical workshops."
+- "Learner motivation in Instructor Training can be very different from the motivation we see in workshops."
 - "Instructors can influence learner motivation with three 'levers' of value, expected efficacy, and a supportive environment."
 - "Carpentries Instructor Training aims to teach several component skills of teaching. However, this does not guarantee that all skills will be actively used. Trainers can prepare trainees to bridge this gap by explicitly discussing application as well as supporting practice and feedback."
 - "Trainers experience expert awareness gaps and cognitive overload too!"
@@ -31,7 +31,7 @@ keypoints:
 2\. Take a moment with Figure 3.2 (p.80). Can you think of an situation you've encountered in a classroom that is explained 
 by this figure?
 
-3\. Do you think learners at Carpentries technical workshops will have primarily learning goals or performance goals? How about at Instructor Training events?
+3\. Do you think learners at Carpentries workshops will have primarily learning goals or performance goals? How about at Instructor Training events?
 
 4\. This chapter offers a number of strategies for establishing value and building positive expectancies (p.83-89). Which are most relevant to Carpentries workshops and trainings? Are any of them **not** relevant in this setting? Why or why not?
 
@@ -40,6 +40,6 @@ by this figure?
 How might these affect learners during Instructor Training? How about Trainers?
 
 6\. When students learn skills but don’t learn how to apply them, they may fail to use those skills when they are relevant. 
-How can we help learners bridge the gap between learning and application? Is this different for Instructor Training vs technical Carpentries workshops?
+How can we help learners bridge the gap between learning and application? Is this different for Instructor Training vs Carpentries workshops?
 
 

--- a/_episodes/04-week_4_discussion_questions.md
+++ b/_episodes/04-week_4_discussion_questions.md
@@ -26,12 +26,12 @@ Bloom's taxonomy does this objective fall under? Examining the chart on p. 246, 
 think this objective is at an appropriate level for Instructor trainees? Why or why not?
 
 #### Chapter 5: What Kinds of Practice and Feedback Enhance Learning?
-3\. This chapter discusses the importance of creating good opportunities for practice. In the context of a technical workshop, what role can an Instructor play in 
+3\. This chapter discusses the importance of creating good opportunities for practice. In the context of a Carpentries workshop, what role can an Instructor play in 
 this regard? A helper?
 
-4\. Feedback is an essential component of effective practice. In what ways do learners in a technical workshop get feedback on their progress? Is that feedback likely to meet the criteria for *useful* feedback outlined in this chapter? Why or why not?
+4\. Feedback is an essential component of effective practice. In what ways do learners in a workshop get feedback on their progress? Is that feedback likely to meet the criteria for *useful* feedback outlined in this chapter? Why or why not?
 
-5\. In both Instructor Training and technical workshops, Carpentries surveys provide feedback from learners, and additional feedback mechanisms (e.g. minute cards 
+5\. In both Instructor Training and workshops, Carpentries surveys provide feedback from learners, and additional feedback mechanisms (e.g. minute cards 
 and one-up-one-down) supplement this for a rich source of information. Do you think there is any additional advantage in asking a co-Instructor or co-Trainer for 
 feedback? Why or why not? If so, how would you go about seeking such feedback?
 

--- a/_episodes/05-week_5_discussion_questions.md
+++ b/_episodes/05-week_5_discussion_questions.md
@@ -7,11 +7,11 @@ questions:
 objectives: 
 - "Explain the impact of The Carpentries Code of Conduct on classroom climate." 
 - "Predict challenges faced by new Instructors in creating a positive classroom climate and propose possible solutions."
-- "Predict challenges faced by new Instructors and technical trainees in transferring metacognitive skills to a new learning process and propose possible solutions."
+- "Predict challenges faced by new Instructors and learners in transferring metacognitive skills to a new learning process and propose possible solutions."
 - "Connect common Carpentries classroom practices with strategies that support metacognition and identify the relationship between them."   
 keypoints:  
 - "The Carpentries Code of Conduct is one of many features that creates a positive classroom climate for Carpentries workshops." 
-- "Instructor trainees will face challenges as they develop skill in teaching. As in technical workshops, a core goal of our two-day training is to prepare them to encounter and surmount those challenges."   
+- "Instructor trainees will face challenges as they develop skill in teaching. As in Carpentries workshops, a core goal of our two-day training is to prepare them to encounter and surmount those challenges."   
 ---
 ## Reading
 _How Learning Works_ 
@@ -25,11 +25,11 @@ _How Learning Works_
 #### Chapter 6: Why do Student Development and Course Climate Matter for Learning?
 2\. How might The Carpentries Code of Conduct function in supporting an "explicitly centralizing"(p.171-172) classroom climate? 
 
-3\. Choose a strategy among those suggested on pages 180-186 that seems useful or essential to a Carpentries technical workshop. What factors might prevent an Instructor from effectively implementing this strategy? As a Trainer, how might you help?
+3\. Choose a strategy among those suggested on pages 180-186 that seems useful or essential to a Carpentries workshop. What factors might prevent an Instructor from effectively implementing this strategy? As a Trainer, how might you help?
 
 #### Chapter 7: How do Students Become Self-directed Learners?
 
-4\. Most of our learners have rich experience with metacognitive strategies, but may not automatically apply them to the content of our technical workshops or Instructor Training. Why do you think this is? How can we support our learners in transferring metacognitive skills appropriately? 
+4\. Most of our learners have rich experience with metacognitive strategies, but may not automatically apply them to the content of our workshops or Instructor Training. Why do you think this is? How can we support our learners in transferring metacognitive skills appropriately? 
 
 5\. (Try not to skip this question.) Try making a concept map that links one or more of the strategies on p.203-215 to one or more practices that could be implemented in a workshop to support metacognition. What concepts did you connect? What relationships did you identify?
 

--- a/_episodes/10-Week_10_discussion_questions.md
+++ b/_episodes/10-Week_10_discussion_questions.md
@@ -20,11 +20,11 @@ skill development goals?
 
 ## Closing Questions:
 
-2\. What questions do you have about your role as an Instructor Trainer?
+2\. What questions do you have about your role as a Trainer?
 
 3\. What questions do you have about The Carpentries community?
 
-4\. What are your goals as an Instructor Trainer?
+4\. What are your goals as a Trainer?
 
 5\. What can The Carpentries Core Team and the Trainer community do to support you in your goals?
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: lesson
 root: .
 permalink: index.html  # Is the only page that don't follow the partner /:path/index.html
 ---
-This is the on-boarding curriculum for new Trainers. This material supports ten 1-hour discussion meetings based on assigned reading from our textbook, [How Learning Works by Ambrose et al.](http://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206), as well as our [Instructor Training Curriculum](https://carpentries.github.io/instructor-training/). Completion of this series is the main step towards certification to teach Carpentries Instructor Training workshops.
+This is the on-boarding curriculum for new Trainers. This material supports ten 1-hour discussion meetings based on assigned reading from our textbook, [How Learning Works by Ambrose et al.](http://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206), as well as our [Instructor Training Curriculum](https://carpentries.github.io/instructor-training/). Completion of this series is the main step towards certification to teach Carpentries Instructor Training courses.
 
 > ## Prerequisites
 >

--- a/index.md
+++ b/index.md
@@ -3,9 +3,9 @@ layout: lesson
 root: .
 permalink: index.html  # Is the only page that don't follow the partner /:path/index.html
 ---
-This is the on-boarding curriculum for new Instructor Trainers. This material supports ten 1-hour discussion meetings based on assigned reading from our textbook, [How Learning Works by Ambrose et al.](http://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206), as well as our [Instructor Training Curriculum](https://carpentries.github.io/instructor-training/). Completion of this series is the main step towards certification to teach Carpentries Instructor Training workshops.
+This is the on-boarding curriculum for new Trainers. This material supports ten 1-hour discussion meetings based on assigned reading from our textbook, [How Learning Works by Ambrose et al.](http://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206), as well as our [Instructor Training Curriculum](https://carpentries.github.io/instructor-training/). Completion of this series is the main step towards certification to teach Carpentries Instructor Training workshops.
 
 > ## Prerequisites
 >
-> This curriculum targets individuals who have applied and been accepted as Carpentries Instructor Trainers. It is generally expected that learners either have extensive background in teaching or have demonstrated commitment to Carpentries teaching practices through involvement with the community. However, no particular background knowledge is necessary to participate fully in these discussions.
+> This curriculum targets individuals who have applied and been accepted as Carpentries Trainers. It is generally expected that learners either have extensive background in teaching or have demonstrated commitment to Carpentries teaching practices through involvement with the community. However, no particular background knowledge is necessary to participate fully in these discussions.
 {: .prereq}


### PR DESCRIPTION
This PR standardises terminology use with other Carpentries' resources, in particular:

- "Instructor Trainer" is changed to "Trainer"
- "Instructor Training workshop" is changed to "Instructor Training course"
- "technical workshop" is changed to "workshop"
- "partner institution" is changed to "Member organisation"

These changes have been discussed with and approved by @SherAaronHurt.