### PR TITLE
Change to 2nd edition of textbook

### DIFF
--- a/episodes/01-week1_discussion_questions.md
+++ b/episodes/01-week1_discussion_questions.md
@@ -1,7 +1,7 @@
 ---
-title: Week 1 Discussion Questions
-teaching: 30
-exercises: 30
+title: Week 1
+teaching: 5
+exercises: 55
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives

--- a/episodes/02_week2_discussion_questions.md
+++ b/episodes/02_week2_discussion_questions.md
@@ -1,5 +1,5 @@
 ---
-title: Week 2 Discussion Questions
+title: Week 2
 teaching: 5
 exercises: 55
 ---
@@ -24,37 +24,37 @@ exercises: 55
 
 *How Learning Works*:
 
-- Chapter 1 + Appendix A
-- Chapter 2 + Appendix B
+- Chapter 2: How Does Students' Prior Knowledge Affect Their Learning? 
+- Appendix A: What Are Instructor Self-Assessments/Reflections and How Can We Use Them? 
+- Chapter 3: How Does the Way Students Organize Knowledge Affect Their Learning?
+- Appendix D: What Are Concept Maps and How Can We Use Them? 
 
 ## Discussion Questions
 
 1\. What stood out to you from this week's reading? This might be key points, things that made sense in light of your own experience, things you're not convinced of, or questions that you have from each chapter.
 
-- Chapter 1
-- Chapter 2
 
 ### *How Learning Works*
 
-#### Chapter 1: How Does Students' Prior Knowledge Affect Their Learning?
+#### Chapter 2: How Does Students' Prior Knowledge Affect Their Learning?
 
 2\.  Give an example of a time from your experience when a learner's prior knowledge negatively affected their learning. Why do you think prior knowledge had
 such an impact in this case? Do you think any of the strategies suggested in this chapter might have helped?
 
-#### Appendix A
+#### Appendix A: What Are Instructor Self-Assessments/Reflections and How Can We Use Them?
 
 3\. Have a look at the [pre-assessment survey](https://carpentries.github.io/assessment-archives/instructor-training-pre/instructor-training-pre.html) for
 Instructor Training events. Can you identify one question that might influence how you approach teaching, depending on the distribution of responses? If you
 could ask one additional question, what would it be?
 
-#### Chapter 2: How Does the Way Students Organize Knowledge Affect Their Learning
+#### Chapter 3: How Does the Way Students Organize Knowledge Affect Their Learning?
 
-4\. Examine Figure 2.2 (p.50 of the print edition). How do these diagrams relate to knowledge or learner mental models that
+4\. Examine Figure 3.2 (p.72). How do these diagrams relate to knowledge or learner mental models that
 you are familiar with? Which do you think best represents a learner who has just taken a Carpentries workshop?
 
-5\. Take a look at the strategies for ways Instructors can assess and enhance their own knowledge organization at the end of Chapter 2 (p. 59-65). Choose one strategy and think about how an Instructor could apply it when preparing to teach a Carpentries workshop. On a scale from 1-10, how challenging do you think it would be for a new Instructor to use?
+5\. Take a look at the strategies for ways Instructors can assess and enhance their own knowledge organization at the end of Chapter 3 (p. 78-83). Choose one strategy and think about how an Instructor could apply it when preparing to teach a Carpentries workshop. On a scale from 1-10, how challenging do you think it would be for a new Instructor to use?
 
-#### Appendix B
+#### Appendix D: What Are Concept Maps and How Can We Use Them? 
 
 6\. \* (Try not to skip this question) Draft a small concept map (3-5 items with labeled connections) for **your own eyes only (not to be shared!)** that partially explains one of the following topics:
 

--- a/episodes/03_week3_discussion_questions.md
+++ b/episodes/03_week3_discussion_questions.md
@@ -1,5 +1,7 @@
 ---
-title: Week 3 Discussion Questions
+title: Week 3
+teaching: 5
+exercises: 55
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives
@@ -16,28 +18,25 @@ title: Week 3 Discussion Questions
 
 *How Learning Works*:
 
-- Chapter 3
-- Chapter 4
+- Chapter 4: What Factors Motivate Students to Learn?
+- Chapter 5: How Do Students Develop Mastery? 
 
 ## Discussion Questions
 
 1\. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
 
-- Chapter 3
-- Chapter 4
-
 ### *How Learning Works*
 
-#### Chapter 3: What Factors Motivate Students to Learn?
+#### Chapter 4: What Factors Motivate Students to Learn?
 
-2\. Take a moment with Figure 3.2 (p.80). Can you think of an situation you've encountered in a classroom that is explained
+2\. Take a moment with Figure 4.2 (p.97). Can you think of an situation you've encountered in a classroom that is explained
 by this figure?
 
 3\. Do you think learners at Carpentries workshops will have primarily learning goals or performance goals? How about at Instructor Training events?
 
-4\. This chapter offers a number of strategies for establishing value and building positive expectancies (p.83-89). Which are most relevant to Carpentries workshops and trainings? Are any of them **not** relevant in this setting? Why or why not?
+4\. This chapter offers a number of strategies for establishing value and building positive expectancies (p.99-104). Which are most relevant to Carpentries workshops and trainings? Are any of them **not** relevant in this setting? Why or why not?
 
-#### Chapter 4: How Do Students Develop Mastery?
+#### Chapter 5: How Do Students Develop Mastery?
 
 5\. This chapter discusses expert "blind spots" (now re-named in our curriculum as ["expert awareness gaps"](https://carpentries.github.io/instructor-training/04-expertise/index.html#expert-awareness-gap)) and cognitive load.
 How might these affect learners during Instructor Training? How about Trainers?

--- a/episodes/04-week_4_discussion_questions.md
+++ b/episodes/04-week_4_discussion_questions.md
@@ -1,5 +1,7 @@
 ---
-title: Week 4 Discussion Questions
+title: Week 4
+teaching: 5
+exercises: 55
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives
@@ -15,8 +17,8 @@ title: Week 4 Discussion Questions
 
 *How Learning Works*:
 
-- Appendix D
-- Chapter 5 - What Kinds of Practice and Feedback Enhance Learning?
+- Appendix G: What are Learning Objectives and How Can We Use Them?
+- Chapter 6: What Kinds of Practice and Feedback Enhance Learning?
 
 ## Discussion Questions
 
@@ -24,13 +26,13 @@ title: Week 4 Discussion Questions
 
 ### *How Learning Works*
 
-#### Appendix D: What are Learning Objectives and How Can We Use Them?
+#### Appendix G: What are Learning Objectives and How Can We Use Them?
 
 2\. One of the learning objectives stated in the Instructor Training curriculum is: "Critically analyze a learning objective for your workshop." What level of
-Bloom's taxonomy does this objective fall under? Examining the chart on p. 246, try re-writing this learning objective at a lower level and a higher level. Do you
+Bloom's taxonomy does this objective fall under? Examining the chart on p. 245, try re-writing this learning objective at a lower level and a higher level. Do you
 think this objective is at an appropriate level for Instructor trainees? Why or why not?
 
-#### Chapter 5: What Kinds of Practice and Feedback Enhance Learning?
+#### Chapter 6: What Kinds of Practice and Feedback Enhance Learning?
 
 3\. This chapter discusses the importance of creating good opportunities for practice. In the context of a Carpentries workshop, what role can an Instructor play in
 this regard? A helper?

--- a/episodes/05-week_5_discussion_questions.md
+++ b/episodes/05-week_5_discussion_questions.md
@@ -1,7 +1,7 @@
 ---
-title: Week 5 Discussion Questions
-teaching: 0
-exercises: 0
+title: Week 5
+teaching: 5
+exercises: 55
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives
@@ -23,8 +23,8 @@ exercises: 0
 
 *How Learning Works*
 
-- Chapter 6: Why Do Student Development and Course Climate Matter?
-- Chapter 7: How Do Students Become Self-Directed Learners?
+- Chapter 7: Why Does Course Climate Matter for Student Learning?
+- Chapter 8: How Do Students Become Self-Directed Learners?
 
 ## Discussion Questions
 
@@ -32,17 +32,17 @@ exercises: 0
 
 ### *How Learning Works*
 
-#### Chapter 6: Why do Student Development and Course Climate Matter for Learning?
+#### Chapter 7: Why Does Course Climate Matter for Student Learning?
 
-2\. How might The Carpentries Code of Conduct function in supporting an "explicitly centralizing"(p.171-172) classroom climate?
+2\. How might The Carpentries Code of Conduct function in supporting an "explicitly centralizing" (p.167) classroom climate?
 
-3\. Choose a strategy among those suggested on pages 180-186 that seems useful or essential to a Carpentries workshop. What factors might prevent an Instructor from effectively implementing this strategy? As a Trainer, how might you help?
+3\. Choose a strategy among those suggested on pages 177-186 that seems useful or essential to a Carpentries workshop. What factors might prevent an Instructor from effectively implementing this strategy? As a Trainer, how might you help?
 
-#### Chapter 7: How do Students Become Self-directed Learners?
+#### Chapter 8: How Do Students Become Self-Directed Learners?
 
 4\. Most of our learners have rich experience with metacognitive strategies, but may not automatically apply them to the content of our workshops or Instructor Training. Why do you think this is? How can we support our learners in transferring metacognitive skills appropriately?
 
-5\. (Try not to skip this question.) Try making a concept map that links one or more of the strategies on p.203-215 to one or more practices that could be implemented in a workshop to support metacognition. What concepts did you connect? What relationships did you identify?
+5\. (Try not to skip this question.) Try making a concept map that links one or more of the strategies on p.200-211 to one or more practices that could be implemented in a workshop to support metacognition. What concepts did you connect? What relationships did you identify?
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/06-Week_6_discussion_questions.md
+++ b/episodes/06-Week_6_discussion_questions.md
@@ -1,7 +1,7 @@
 ---
-title: Week 6 Discussion Questions
-teaching: 0
-exercises: 0
+title: Week 6
+teaching: 5
+exercises: 55
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives
@@ -35,7 +35,7 @@ exercises: 0
 
 #### [Welcome](https://carpentries.github.io/instructor-training/01-welcome)
 
-2\. This module introduces the Instructor Training event. Depending on how Trainers use the curriculum, this section can be more or less interactive and can
+2\. This episode introduces the Instructor Training event. Depending on how Trainers use the curriculum, this section can be more or less interactive and can
 take more or less time than it is formally allocated. This is especially important when trainings get off to a slow start for logistical reasons. Try to identify
 one opportunity for interaction with learners during this episode. How might you use this to establish a positive learning environment without running out the
 clock?
@@ -46,7 +46,7 @@ clock?
 How did you describe the relationship between teaching and learning? What other concepts and relationships did you include?
 If you would like to try an online tool for this, visit [https://excalidraw.com](https://excalidraw.com).
 
-4\. We introduce skill acquisition in this module, but really dig into expertise in the next. What is the purpose of introducing skill acquisition here? What
+4\. We introduce skill acquisition in this episode, but really dig into expertise in the next. What is the purpose of introducing skill acquisition here? What
 should be emphasized here, vs in the next section?
 
 #### [Expertise and Instruction](https://carpentries.github.io/instructor-training/04-expertise)

--- a/episodes/07-Week_7_discussion_questions.md
+++ b/episodes/07-Week_7_discussion_questions.md
@@ -1,7 +1,7 @@
 ---
-title: Week 7 Discussion Questions
-teaching: 0
-exercises: 0
+title: Week 7
+teaching: 5
+exercises: 55
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives

--- a/episodes/08-Week_8_discussion_questions.md
+++ b/episodes/08-Week_8_discussion_questions.md
@@ -1,7 +1,7 @@
 ---
-title: Week 8 Discussion Questions
-teaching: 0
-exercises: 0
+title: Week 8
+teaching: 5
+exercises: 55
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives

--- a/episodes/09-Week_9_discussion_questions.md
+++ b/episodes/09-Week_9_discussion_questions.md
@@ -1,7 +1,7 @@
 ---
-title: Week 9 Discussion Questions
-teaching: 0
-exercises: 0
+title: Week 9
+teaching: 5
+exercises: 55
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives

--- a/episodes/10-Week_10_discussion_questions.md
+++ b/episodes/10-Week_10_discussion_questions.md
@@ -1,18 +1,18 @@
 ---
-title: Week 10 Discussion Questions
-teaching: 0
-exercises: 0
+title: Week 10
+teaching: 5
+exercises: 55
 ---
 
 ## Reading:
 
 Examine [The Carpentries Handbook: Teaching and Hosting](https://docs.carpentries.org/topic_folders/hosts_instructors/index.html)  
 Review [Trainer Guide](https://docs.carpentries.org/topic_folders/instructor_training/trainers_guide.html)  
-*How Learning Works*: Conclusion (p. 217-224)
+*How Learning Works*: Conclusion (p. 212-218)
 
 ### *How Learning Works*
 
-#### Conclusion p. 217-224
+#### Conclusion p. 212-218
 
 1\. What is one area of teaching skill that you would like to work on? How did you decide on that goal? How could you advise an Instructor to prioritize their
 skill development goals?

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ permalink: index.html
 site: sandpaper::sandpaper_site
 ---
 
-This is the on-boarding curriculum for new Trainers. This material supports ten 1-hour discussion meetings based on assigned reading from our textbook, [How Learning Works by Ambrose et al.](https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206), as well as our [Instructor Training Curriculum](https://carpentries.github.io/instructor-training/). Completion of this series is the main step towards certification to teach Carpentries Instructor Training courses.
+This is the on-boarding curriculum for new Trainers. This material supports ten one-hour discussion meetings based on assigned reading from our textbook, [How Learning Works by Lovett et al.](https://search.worldcat.org/title/1373343202), as well as our [Instructor Training Curriculum](https://carpentries.github.io/instructor-training/). Completion of this series is the main step towards certification to teach Carpentries Instructor Training courses.
 
 ::::::::::::::::::::::::::::::::::::::::::  prereq
 


### PR DESCRIPTION
This PR does the following: 
- update link to 2nd edition of the book
- update page numbers, chapter numbers, and chapter titles
- change "module" to "episode" for consistency with Carpentries terminology
- remove repetitive "Discussion Question" from episode titles