### PR TITLE
Reorder readings and questions

### DIFF
--- a/episodes/01-week1_discussion_questions.md
+++ b/episodes/01-week1_discussion_questions.md
@@ -20,9 +20,7 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: prereq
 
-## Required Reading
-
-Read the following before our meeting: 
+## Reading
 
 From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206):
 

--- a/episodes/02_week2_discussion_questions.md
+++ b/episodes/02_week2_discussion_questions.md
@@ -39,22 +39,25 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 ## Discussion Questions
 
-1. What stood out to you from this week's reading? This might be key points, things that made sense in light of your own experience, things you're not convinced of, or questions that you have from each chapter.
 
-1.  Give an example of a time from your experience when a learner's prior knowledge negatively affected their learning. Why do you think prior knowledge had
-such an impact in this case? Do you think any of the strategies suggested in this chapter might have helped?
+1. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
 
-1. Have a look at the [pre-assessment survey](https://carpentries.github.io/assessment-archives/instructor-training-pre/instructor-training-pre.html) for
-Instructor Training events. Can you identify one question that might influence how you approach teaching, depending on the distribution of responses? If you
-could ask one additional question, what would it be?
+1. Give an example of a time from your experience when a learner’s prior knowledge negatively affected their learning. Why do you think prior knowledge had such an impact in this case? Do you think any of the strategies suggested in this chapter might have helped?
 
-1. Draft a small concept map (3-5 items with labeled connections) for **your own eyes only (not to be shared!)** that partially explains one of the following topics:
+1. Read the pre-assessment survey for Instructor Training. How do trainee responses to this survey influence your teaching? 
 
-- Prior knowledge
-- Knowledge organization
-- Workshop organization
+1. Create a concept map (3-5 items with labeled connections) that includes “teaching” and “learning” as concepts. How did you describe the relationship between teaching and learning? What other concepts and relationships did you include? 
 
+1. Examine Figure 3.2 (p.72). How do these diagrams relate to knowledge or learner mental models that you are familiar with? Which do you think best represents a learner who has just taken a Carpentries workshop?
+
+1. Read the strategies for how Instructors can assess and enhance their own knowledge organization at the end of Chapter 3 (p. 78-83). Choose one strategy and think about how an Instructor could apply it when preparing to teach a Carpentries workshop. On a scale from 1-10, how challenging do you think it would be for a new Instructor to use?
+
+1. Create a concept map (3-5 items with labeled connections) that partially explains one of the following topics:
+	- Prior knowledge
+	- Knowledge organization
+	- Workshop organization  
 Then, share your experience with the process. Did you learn anything from making this map? How could you organize it differently if you tried it again?
+
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/02_week2_discussion_questions.md
+++ b/episodes/02_week2_discussion_questions.md
@@ -15,48 +15,35 @@ exercises: 55
 
 :::::::::::::::::::::::::::::::::::::::: questions
 
-- How can prior knowledge influence a workshop or training experience, and how can we plan to adjust to variation?
-- How can the structure of information be explored and made explicit to support learning in a workshop or training event?
+- See discussion questions.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+::::::::::::::::::::::::::::::::::: prereq
+
 ## Reading
 
-*How Learning Works*:
+From *How Learning Works*:
 
-- Chapter 2: How Does Students' Prior Knowledge Affect Their Learning? 
-- Appendix A: What Are Instructor Self-Assessments/Reflections and How Can We Use Them? 
-- Chapter 3: How Does the Way Students Organize Knowledge Affect Their Learning?
-- Appendix D: What Are Concept Maps and How Can We Use Them? 
+- Chapter 1: Why Do Students' Identities and Stages of Development Matter for Learning? (pp. 9-38)
+- Chapter 2: How Does Students' Prior Knowledge Affect Their Learning? (pp. 39-63)
+- Appendix A: What Are Instructor Self-Assessments/Reflections and How Can We Use Them? (pp. 219-225)
+
+:::::::::::::::::::::::::::::::::::::::::::::::::
+
 
 ## Discussion Questions
 
-1\. What stood out to you from this week's reading? This might be key points, things that made sense in light of your own experience, things you're not convinced of, or questions that you have from each chapter.
+1. What stood out to you from this week's reading? This might be key points, things that made sense in light of your own experience, things you're not convinced of, or questions that you have from each chapter.
 
-
-### *How Learning Works*
-
-#### Chapter 2: How Does Students' Prior Knowledge Affect Their Learning?
-
-2\.  Give an example of a time from your experience when a learner's prior knowledge negatively affected their learning. Why do you think prior knowledge had
+1.  Give an example of a time from your experience when a learner's prior knowledge negatively affected their learning. Why do you think prior knowledge had
 such an impact in this case? Do you think any of the strategies suggested in this chapter might have helped?
 
-#### Appendix A: What Are Instructor Self-Assessments/Reflections and How Can We Use Them?
-
-3\. Have a look at the [pre-assessment survey](https://carpentries.github.io/assessment-archives/instructor-training-pre/instructor-training-pre.html) for
+1. Have a look at the [pre-assessment survey](https://carpentries.github.io/assessment-archives/instructor-training-pre/instructor-training-pre.html) for
 Instructor Training events. Can you identify one question that might influence how you approach teaching, depending on the distribution of responses? If you
 could ask one additional question, what would it be?
 
-#### Chapter 3: How Does the Way Students Organize Knowledge Affect Their Learning?
-
-4\. Examine Figure 3.2 (p.72). How do these diagrams relate to knowledge or learner mental models that
-you are familiar with? Which do you think best represents a learner who has just taken a Carpentries workshop?
-
-5\. Take a look at the strategies for ways Instructors can assess and enhance their own knowledge organization at the end of Chapter 3 (p. 78-83). Choose one strategy and think about how an Instructor could apply it when preparing to teach a Carpentries workshop. On a scale from 1-10, how challenging do you think it would be for a new Instructor to use?
-
-#### Appendix D: What Are Concept Maps and How Can We Use Them? 
-
-6\. \* (Try not to skip this question) Draft a small concept map (3-5 items with labeled connections) for **your own eyes only (not to be shared!)** that partially explains one of the following topics:
+1. Draft a small concept map (3-5 items with labeled connections) for **your own eyes only (not to be shared!)** that partially explains one of the following topics:
 
 - Prior knowledge
 - Knowledge organization

--- a/episodes/02_week2_discussion_questions.md
+++ b/episodes/02_week2_discussion_questions.md
@@ -19,15 +19,20 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-::::::::::::::::::::::::::::::::::: prereq
+::::::::::::::::::::::::::::::::::::::: prereq
 
 ## Reading
 
-From *How Learning Works*:
+From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206):
 
-- Chapter 1: Why Do Students' Identities and Stages of Development Matter for Learning? (pp. 9-38)
-- Chapter 2: How Does Students' Prior Knowledge Affect Their Learning? (pp. 39-63)
-- Appendix A: What Are Instructor Self-Assessments/Reflections and How Can We Use Them? (pp. 219-225)
+* Chapter 2: How Does Student’s Prior Knowledge Affect Their Learning? (p. 39 - 63)
+* Chapter 3: How Does the Way Students Organize Knowledge Affect Their Learning? (p. 64 - 83)
+* Appendix D: What Are Concept Maps and How Can We Use Them? (p. 229 - 231)
+
+From The Carpentries [Instructor Training curriculum](https://carpentries.github.io/instructor-training/instructor/index.html): 
+
+* [Building Skill with Practice](https://carpentries.github.io/instructor-training/instructor/02-practice-learning.html)
+
 
 :::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/03_week3_discussion_questions.md
+++ b/episodes/03_week3_discussion_questions.md
@@ -42,25 +42,20 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 1. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
 
-1. Examine Figure 3.2 (p.72). How do these diagrams relate to knowledge or learner mental models that
-you are familiar with? Which do you think best represents a learner who has just taken a Carpentries workshop?
+1. There are many demotivating “traps” an instructor can fall into. What strategies can we give our instructors for recovering from these slip-ups?
 
-1. Take a look at the strategies for ways Instructors can assess and enhance their own knowledge organization at the end of Chapter 3 (p. 78-83). Choose one strategy and think about how an Instructor could apply it when preparing to teach a Carpentries workshop. On a scale from 1-10, how challenging do you think it would be for a new Instructor to use?
+1. How might the concepts taught in this lesson apply to the process of learning to becoming a better teacher?
 
-1. Take a moment with Figure 4.2 (p.97). Can you think of an situation you've encountered in a classroom that is explained
-by this figure?
+1. How can we support our learners in transferring metacognitive skills to the materials learned in a workshop?
 
-1. Do you think learners at Carpentries workshops will have primarily learning goals or performance goals? How about at Instructor Training events?
+1. Make a concept map (3-5 items with labeled connections) that links one or more of the strategies on p.200-211 to one or more practices that could be implemented in a workshop to support metacognition. What concepts did you connect? What relationships did you identify?
 
-1. This chapter offers a number of strategies for establishing value and building positive expectancies (p.99-104). Which are most relevant to Carpentries workshops and trainings? Are any of them **not** relevant in this setting? Why or why not?
+1. Examine Figure 4.2 (p.97). Think of an situation you’ve encountered in a classroom that is explained by this figure.
 
-#### Chapter 5: How Do Students Develop Mastery?
+1. Will learners at Carpentries workshops  have primarily learning goals or performance goals? What about at Instructor Training events?
 
-5\. This chapter discusses expert "blind spots" (now re-named in our curriculum as ["expert awareness gaps"](https://carpentries.github.io/instructor-training/04-expertise/index.html#expert-awareness-gap)) and cognitive load.
-How might these affect learners during Instructor Training? How about Trainers?
+1. Which are the strategies on p.99-104 are most relevant to Carpentries workshops and trainings? Are any of them not relevant in this setting? Why or why not?
 
-6\. When students learn skills but don't learn how to apply them, they may fail to use those skills when they are relevant.
-How can we help learners bridge the gap between learning and application? Is this different for Instructor Training vs Carpentries workshops?
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/03_week3_discussion_questions.md
+++ b/episodes/03_week3_discussion_questions.md
@@ -14,27 +14,42 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+
+:::::::::::::::::::::::::::::::::::::::: questions
+
+- See discussion questions.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::: prereqs
+
 ## Reading
 
 *How Learning Works*:
 
-- Chapter 4: What Factors Motivate Students to Learn?
-- Chapter 5: How Do Students Develop Mastery? 
+- Chapter 3: How Does the Way Students Organize Knowledge Affect Their Learning? (pp. 64-83)
+- Appendix D: What Are Concept Maps and How Can We Use Them? (pp. 229-231)
+- Chapter 4: What Factors Motivate Students to Learn? (pp. 84-105)
+- Chapter 5: How Do Students Develop Mastery? (pp. 106-129)
+
+:::::::::::::::::::::::::::::::::::::::::::::::::
+
 
 ## Discussion Questions
 
-1\. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
+1. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
 
-### *How Learning Works*
+1. Examine Figure 3.2 (p.72). How do these diagrams relate to knowledge or learner mental models that
+you are familiar with? Which do you think best represents a learner who has just taken a Carpentries workshop?
 
-#### Chapter 4: What Factors Motivate Students to Learn?
+1. Take a look at the strategies for ways Instructors can assess and enhance their own knowledge organization at the end of Chapter 3 (p. 78-83). Choose one strategy and think about how an Instructor could apply it when preparing to teach a Carpentries workshop. On a scale from 1-10, how challenging do you think it would be for a new Instructor to use?
 
-2\. Take a moment with Figure 4.2 (p.97). Can you think of an situation you've encountered in a classroom that is explained
+1. Take a moment with Figure 4.2 (p.97). Can you think of an situation you've encountered in a classroom that is explained
 by this figure?
 
-3\. Do you think learners at Carpentries workshops will have primarily learning goals or performance goals? How about at Instructor Training events?
+1. Do you think learners at Carpentries workshops will have primarily learning goals or performance goals? How about at Instructor Training events?
 
-4\. This chapter offers a number of strategies for establishing value and building positive expectancies (p.99-104). Which are most relevant to Carpentries workshops and trainings? Are any of them **not** relevant in this setting? Why or why not?
+1. This chapter offers a number of strategies for establishing value and building positive expectancies (p.99-104). Which are most relevant to Carpentries workshops and trainings? Are any of them **not** relevant in this setting? Why or why not?
 
 #### Chapter 5: How Do Students Develop Mastery?
 

--- a/episodes/03_week3_discussion_questions.md
+++ b/episodes/03_week3_discussion_questions.md
@@ -21,16 +21,19 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-::::::::::::::::::::::::::::::::::: prereqs
+::::::::::::::::::::::::::::::::::: prereq
 
 ## Reading
 
-*How Learning Works*:
+From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206):
 
-- Chapter 3: How Does the Way Students Organize Knowledge Affect Their Learning? (pp. 64-83)
-- Appendix D: What Are Concept Maps and How Can We Use Them? (pp. 229-231)
-- Chapter 4: What Factors Motivate Students to Learn? (pp. 84-105)
-- Chapter 5: How Do Students Develop Mastery? (pp. 106-129)
+* Chapter 4: What Factors Motivate Students to Learn? (p. 84 - 105)
+* Chapter 8: How Do Students Become Self-Directed Learners? (p. 187 - 211)
+
+From The Carpentries [Instructor Training curriculum](https://carpentries.github.io/instructor-training/instructor/index.html): 
+
+* [Motivation and Demotivation](https://carpentries.github.io/instructor-training/instructor/08-motivation.html)
+
 
 :::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/04-week_4_discussion_questions.md
+++ b/episodes/04-week_4_discussion_questions.md
@@ -13,12 +13,29 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+
+:::::::::::::::::::::::::::::::::::::::::::::::::: questions
+
+- See discussion questions.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+
+:::::::::::::::::::::::::::::::::::::::::::::::::: prereq
+
 ## Reading
 
-*How Learning Works*:
+From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206):
 
-- Appendix G: What are Learning Objectives and How Can We Use Them?
-- Chapter 6: What Kinds of Practice and Feedback Enhance Learning?
+* Chapter 5: How Do Students Develop Mastery? (p. 106 - 129)
+* Appendix C: What Are Student Self-Assessments and How Can We Use Them? (p. 226 - 228)
+
+From The Carpentries [Instructor Training curriculum](https://carpentries.github.io/instructor-training/instructor/index.html): 
+ 
+* [Expertise and Instruction](https://carpentries.github.io/instructor-training/instructor/04-expertise.html)
+* [Memory and Cognitive Load](https://carpentries.github.io/instructor-training/instructor/05-memory.html)
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ## Discussion Questions
 

--- a/episodes/04-week_4_discussion_questions.md
+++ b/episodes/04-week_4_discussion_questions.md
@@ -39,26 +39,15 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 ## Discussion Questions
 
-1\. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
+1. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
 
-### *How Learning Works*
+1. Many of our curricula contain more content than can be covered in our ‘2-day’ format. How can we help our trainees remember to keep it slow and resist the urge to ‘get through’ everything by talking faster?
 
-#### Appendix G: What are Learning Objectives and How Can We Use Them?
+1. What expert awareness gaps might you have on the subject of teaching or learning? How might such gaps become apparent when teaching others how to teach?
 
-2\. One of the learning objectives stated in the Instructor Training curriculum is: "Critically analyze a learning objective for your workshop." What level of
-Bloom's taxonomy does this objective fall under? Examining the chart on p. 245, try re-writing this learning objective at a lower level and a higher level. Do you
-think this objective is at an appropriate level for Instructor trainees? Why or why not?
+1. How might “blind spots” (now re-named in our curriculum as “expert awareness gaps”) and cognitive load affect learners during Instructor Training? What about Trainers?
 
-#### Chapter 6: What Kinds of Practice and Feedback Enhance Learning?
-
-3\. This chapter discusses the importance of creating good opportunities for practice. In the context of a Carpentries workshop, what role can an Instructor play in
-this regard? A helper?
-
-4\. Feedback is an essential component of effective practice. In what ways do learners in a workshop get feedback on their progress? Is that feedback likely to meet the criteria for *useful* feedback outlined in this chapter? Why or why not?
-
-5\. In both Instructor Training and workshops, Carpentries surveys provide feedback from learners, and additional feedback mechanisms (e.g. minute cards
-and one-up-one-down) supplement this for a rich source of information. Do you think there is any additional advantage in asking a co-Instructor or co-Trainer for
-feedback? Why or why not? If so, how would you go about seeking such feedback?
+1. How can we help learners bridge the gap between learning and application? Is this different for Instructor Training vs Carpentries workshops?
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/05-week_5_discussion_questions.md
+++ b/episodes/05-week_5_discussion_questions.md
@@ -38,21 +38,16 @@ From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-se
 
 ## Discussion Questions
 
-1\. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
+1. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
 
-### *How Learning Works*
+1. Write a learner profile for an Instructor trainee and share with the group (see the [“Additional Exercises”](https://carpentries.github.io/instructor-training/additional_exercises#episode-15-preparing-to-teach) page for detailed instructions on learner profiles). How different are your profiles? What kinds of support might each of your imaginary trainees need?
 
-#### Chapter 7: Why Does Course Climate Matter for Student Learning?
+1. The exercise on [evaluating learning objectives](https://carpentries.github.io/instructor-training/18-preparation#evaluate-learning-objectives) still needs work. The goal is to get learners a) looking at learning objectives critically and b) thinking in levels like Bloom’s Taxonomy without actually introducing the jargon and complexities of the Bloom’s model. In practice, however, learners are very prone to thinking in terms of steps rather than levels of cognitive challenge. Can you think of a change to this exercise, or a different exercise entirely, that might be more effective?
 
-2\. How might The Carpentries Code of Conduct function in supporting an "explicitly centralizing" (p.167) classroom climate?
+1. How do you feel about the prospect of handling a Code of Conduct incident at an event? What questions do you have?
 
-3\. Choose a strategy among those suggested on pages 177-186 that seems useful or essential to a Carpentries workshop. What factors might prevent an Instructor from effectively implementing this strategy? As a Trainer, how might you help?
+1. One of the learning objectives stated in the Instructor Training curriculum is: “Critically analyze a learning objective for your workshop.” What level of Bloom’s taxonomy does this objective fall under? Examining the chart on p. 245, try re-writing this learning objective at a lower level and a higher level. Do you think this objective is at an appropriate level for Instructor trainees? Why or why not?
 
-#### Chapter 8: How Do Students Become Self-Directed Learners?
-
-4\. Most of our learners have rich experience with metacognitive strategies, but may not automatically apply them to the content of our workshops or Instructor Training. Why do you think this is? How can we support our learners in transferring metacognitive skills appropriately?
-
-5\. (Try not to skip this question.) Try making a concept map that links one or more of the strategies on p.200-211 to one or more practices that could be implemented in a workshop to support metacognition. What concepts did you connect? What relationships did you identify?
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/05-week_5_discussion_questions.md
+++ b/episodes/05-week_5_discussion_questions.md
@@ -15,16 +15,26 @@ exercises: 55
 
 :::::::::::::::::::::::::::::::::::::::: questions
 
-- Key question
+- See discussion questions.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:::::::::::::::::::::::::::::::::::::::::::::::::: prereq
+
 ## Reading
 
-*How Learning Works*
+From The Carpentries [Instructor Training curriculum](https://carpentries.github.io/instructor-training/instructor/index.html): 
 
-- Chapter 7: Why Does Course Climate Matter for Student Learning?
-- Chapter 8: How Do Students Become Self-Directed Learners?
+* [Preparing to Teach](https://carpentries.github.io/instructor-training/instructor/18-preparation.html)
+* [Working with Your Team](https://carpentries.github.io/instructor-training/instructor/21-management.html)
+
+From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206):
+
+* Appendix G: What Are Learning Objectives and How Can We Use Them? (p. 244 - 246)
+* Appendix H: What Are Active Learning Strategies and How Can We Use Them? (p. 247 - 249)
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
 
 ## Discussion Questions
 

--- a/episodes/06-Week_6_discussion_questions.md
+++ b/episodes/06-Week_6_discussion_questions.md
@@ -31,40 +31,25 @@ From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-se
 From The Carpentries [Instructor Training curriculum](https://carpentries.github.io/instructor-training/instructor/index.html): 
 
 * [Teaching is a Skill](https://carpentries.github.io/instructor-training/instructor/11-practice-teaching.html)
+* [Building Skill With Feedback](https://carpentries.github.io/instructor-training/instructor/06-feedback.html)
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+## Discussion Questions
 
-### Instructor Training Curriculum
+1. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
 
-1\. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
+1. When trainees give feedback, especially when giving feedback to themselves, they are VERY likely to comment on the number of times they said “um” or “uh” during their practice presentation. How would you go about helping them to level up their feedback to address more impactful features?
 
-#### [Welcome](https://carpentries.github.io/instructor-training/01-welcome)
+1. Responses to Carpentries pre- and post- surveys are intended to be useful to Instructors, Hosts, and The Carpentries. In particular, we aspire to using data from these surveys to improve understanding of the functionality of our programming as well as promote our successes and needs to funders. This is critical to the sustainability of The Carpentries overall. However, this requires that surveys be systematically administered. Nobody likes surveys, and it’s not fun to hound people to take them, either. What can we do to persuade Instructors to make more consistent use of these important assessment tools? (Responses might include ways to make the surveys themselves more useful.)
 
-2\. This episode introduces the Instructor Training event. Depending on how Trainers use the curriculum, this section can be more or less interactive and can
-take more or less time than it is formally allocated. This is especially important when trainings get off to a slow start for logistical reasons. Try to identify
-one opportunity for interaction with learners during this episode. How might you use this to establish a positive learning environment without running out the
-clock?
+1. In the context of a Carpentries workshop, what role does an Instructor play in creating opportunities for practice? What role does a helper play?
 
-#### [Building Skill With Practice](https://carpentries.github.io/instructor-training/02-practice-learning)
+1. In what ways do learners in a workshop get feedback on their progress? Is that feedback likely to meet the criteria for useful feedback outlined in this chapter? Why or why not?
 
-3\. (**Try not to skip this one!**) Try creating a small concept map that includes "teaching" and "learning" as concepts.
-How did you describe the relationship between teaching and learning? What other concepts and relationships did you include?
-If you would like to try an online tool for this, visit [https://excalidraw.com](https://excalidraw.com).
+1. In both Instructor Training and workshops, Carpentries surveys provide feedback from learners, and additional feedback mechanisms (e.g. minute cards and one-up-one-down) supplement this for a rich source of information. Do you think there is any additional advantage in asking a co-Instructor or co-Trainer for feedback? Why or why not? If so, how would you go about seeking such feedback?
 
-4\. We introduce skill acquisition in this episode, but really dig into expertise in the next. What is the purpose of introducing skill acquisition here? What
-should be emphasized here, vs in the next section?
-
-#### [Expertise and Instruction](https://carpentries.github.io/instructor-training/04-expertise)
-
-5\. Do you think you might have any expert awareness gaps on the subject of teaching or learning? How might such gaps become apparent when teaching others how to teach?
-
-#### [Memory and Cognitive Load](https://carpentries.github.io/instructor-training/05-memory)
-
-6\. This episode explains why we should teach slowly and allow time for practice. However, many of our curricula contain
-more content than can sometimes be covered in our '2-day' format. How can we help our trainees remember to keep it slow and
-resist the urge to 'get through' everything by talking faster?
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/06-Week_6_discussion_questions.md
+++ b/episodes/06-Week_6_discussion_questions.md
@@ -16,18 +16,25 @@ exercises: 55
 
 :::::::::::::::::::::::::::::::::::::::: questions
 
-- Key question.
+- See discussion questions.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:::::::::::::::::::::::::::::::::::::::::::::::::: prereq
+
 ## Reading:
 
-[Welcome](https://carpentries.github.io/instructor-training/01-welcome)  
-[Instructor Training: Building Skill With Practice](https://carpentries.github.io/instructor-training/02-practice-learning)  
-[Instructor Training: Expertise and Instruction](https://carpentries.github.io/instructor-training/04-expertise)  
-[Instructor Training: Memory and Cognitive Load](https://carpentries.github.io/instructor-training/05-memory)  
-[Trainer Notes](https://carpentries.github.io/instructor-training/instructor/instructor-notes.html)  
-[Etherpad Template](https://pad.carpentries.org/ttt-template)  - skim
+From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206):
+
+* Chapter 6: What Kinds of Practice and Feedback Enhance Learning? (p. 130 - 161)
+
+From The Carpentries [Instructor Training curriculum](https://carpentries.github.io/instructor-training/instructor/index.html): 
+
+* [Teaching is a Skill](https://carpentries.github.io/instructor-training/instructor/11-practice-teaching.html)
+
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
 
 ### Instructor Training Curriculum
 

--- a/episodes/07-Week_7_discussion_questions.md
+++ b/episodes/07-Week_7_discussion_questions.md
@@ -34,33 +34,9 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 ## Discussion Questions
 
-1\. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
+1. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
 
-#### [Building Skill With Feedback](https://carpentries.github.io/instructor-training/06-feedback.html)
-
-2\. Reponses to Carpentries pre- and post- surveys are intended to be useful to Instructors, Hosts, and The Carpentries. In particular, we aspire to using data
-from these surveys to improve understanding of the functionality of our programming as well as promote our successes and needs to funders.
-This is critical to the sustainability of The Carpentries overall.
-However, this requires that surveys be systematically administered. Nobody *likes* surveys, and it's not fun to hound people to take them, either. What can we do to
-persuade Instructors to make more consistent use of these important assessment tools? (Responses might include ways to make the surveys themselves more useful.)
-
-#### [Motivation and Demotivation](https://carpentries.github.io/instructor-training/08-motivation.html)
-
-3\. Avoiding demotivating learners is at least as important as motivating them, but there are many demotivating "traps" an
-instructor can fall into even when they are aware of the problem. What strategies can we give our instructors for recovering
-from these slip-ups?
-
-4\. How might the concepts taught in this lesson apply to the process of learning to becoming a better teacher?
-
-#### [Equity, Inclusion, and Accessibility](https://carpentries.github.io/instructor-training/09-eia.html)
-
-5\. This is a new episode and will continue to develop over time. What content do you think might be missing that would be important for our Instructors to
-understand in the context of Carpentries workshops?
-
-#### [Teaching is a Skill](https://carpentries.github.io/instructor-training/11-practice-teaching.html)
-
-6\. When trainees give feedback, especially when giving feedback to themselves, they are VERY likely to comment on the number of times they said "um" or "uh"
-during their practice presentation. How would you go about helping them to level up their feedback to address more impactful features?
+1. More questions TBD
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/07-Week_7_discussion_questions.md
+++ b/episodes/07-Week_7_discussion_questions.md
@@ -14,14 +14,23 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:::::::::::::::::::::::::::::::::::::::::::::::::: questions
+
+- See discussion questions.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::::::::::::::::: prereq 
+
 ## Reading:
 
-[Building Skill With Feedback](https://carpentries.github.io/instructor-training/06-feedback.html)  
-[Motivation and Demotivation](https://carpentries.github.io/instructor-training/08-motivation.html)  
-[Equity, Inclusion, and Accessibility](https://carpentries.github.io/instructor-training/09-eia.html)  
-[Teaching is a Skill](https://carpentries.github.io/instructor-training/11-practice-teaching.html)  
-[Wrap-up and Homework](https://carpentries.github.io/instructor-training/12-homework.html)  
-[Welcome Back](https://carpentries.github.io/instructor-training/13-second-welcome.html)
+From The Carpentries [Instructor Training curriculum](https://carpentries.github.io/instructor-training/instructor/index.html): 
+
+* [Live Coding is a Skill](https://carpentries.github.io/instructor-training/instructor/17-live.html)
+* [More Practice Live Coding](https://carpentries.github.io/instructor-training/instructor/20-performance.html)
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
 
 ## Discussion Questions
 

--- a/episodes/08-Week_8_discussion_questions.md
+++ b/episodes/08-Week_8_discussion_questions.md
@@ -13,13 +13,30 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:::::::::::::::::::::::::::::::::::::::::::::::::: questions
+
+- See discussion questions.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::::::::::::::::: prereq
+
 ## Reading:
 
-[Getting Started on Instructor Certification](https://carpentries.github.io/instructor-training/14-checkout.html)  
-[The Carpentries: How We Operate](https://carpentries.github.io/instructor-training/15-carpentries.html)  
-[Live Coding is a Skill](https://carpentries.github.io/instructor-training/17-live.html)  
-[Preparing to Teach](https://carpentries.github.io/instructor-training/18-preparation.html)  
-[More Practice Live Coding](https://carpentries.github.io/instructor-training/20-performance.html)
+From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206):
+
+* Chapter 1: Why Do Students’ Identities and Stages of Development Matter for Learning? (p. 9 - 38)
+* Chapter 7: Why Does Course Climate Matter for Student Learning? (p. 162 - 186)
+* Appendix A: What are Instructor Self-Assessments / Reflections and How Can We Use Them? (p. 219 - 222)
+* Appendix B: What are Ground Rules and How Can We Use Them? (p. 223 - 225)
+
+From The Carpentries [Instructor Training curriculum](https://carpentries.github.io/instructor-training/instructor/index.html): 
+
+* [Equity, Inclusion, and Accessibility](https://carpentries.github.io/instructor-training/instructor/09-eia.html)
+* [Welcome](https://carpentries.github.io/instructor-training/instructor/01-welcome.html)
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
 
 ## Discussion Questions
 

--- a/episodes/08-Week_8_discussion_questions.md
+++ b/episodes/08-Week_8_discussion_questions.md
@@ -40,29 +40,16 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 ## Discussion Questions
 
-### Instructor Training Curriculum
+1. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
 
-1\. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
+1. What content do you think might be missing from the Equity, Inclusion, and Accessibility episode that would be important for our Instructors to understand in the context of Carpentries workshops?
 
-#### [Checkout Process](https://carpentries.github.io/instructor-training/14-checkout.html)
+1. Try to identify one opportunity for interaction with learners during the Welcome episode. How might you use this to establish a positive learning environment without running out the clock?
 
-2\. Not all trainees are interested in completing checkout for certification. We're ok with that! What we worry about is
-when trainees who *do* want to certify are intimidated or deterred by some part of the process. What role can a Trainer play
-in supporting or encouraging trainees who want to complete the checkout process?
+1. How might The Carpentries Code of Conduct function in supporting an “explicitly centralizing” (p.167) classroom climate?
 
-#### [The Carpentries: How We Operate](https://carpentries.github.io/instructor-training/15-carpentries.html)
+1. Choose a strategy among those suggested on pages 177-186 that seems useful or essential to a Carpentries workshop. What factors might prevent an Instructor from effectively implementing this strategy? As a Trainer, how might you help?
 
-3\. What questions do you have about policies and procedures for running a workshop? Where do you think trainees might find this information confusing or unclear?
-
-#### [Preparing to Teach](https://carpentries.github.io/instructor-training/18-preparation.html)
-
-4\. Write a learner profile for an Instructor trainee and share with the group (see the ["Additional Exercises" page](https://carpentries.github.io/instructor-training/additional_exercises#episode-15-preparing-to-teach) for detailed instructions on learner profiles). How different are your profiles? What kinds of support might each of your
-imaginary trainees need?
-
-5\. The exercise on [evaluating learning objectives](https://carpentries.github.io/instructor-training/18-preparation#evaluate-learning-objectives) still needs work. The goal is to get learners a) looking at learning objectives critically and
-b) thinking in levels *like* Bloom's Taxonomy without
-actually introducing the jargon and complexities of the Bloom's model. In practice, however, learners are very prone to thinking in terms of **steps** rather
-than **levels** of cognitive challenge. Can you think of a change to this exercise, or a different exercise entirely, that might be more effective?
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/09-Week_9_discussion_questions.md
+++ b/episodes/09-Week_9_discussion_questions.md
@@ -37,21 +37,11 @@ From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-se
 
 ## Discussion Questions
 
-1\. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
+1. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
 
-### Instructor Training Curriculum
+1. Not all trainees are interested in completing checkout for certification. We’re ok with that! What we worry about is when trainees who do want to certify are intimidated or deterred by some part of the process. What role can a Trainer play in supporting or encouraging trainees who want to complete the checkout process?
 
-#### [Working With Your Team](https://carpentries.github.io/instructor-training/21-management.html)
-
-2\. How do *you* feel about the prospect of handling a Code of Conduct incident at an event? What questions do you have?
-
-#### [Launches and Landings](https://carpentries.github.io/instructor-training/23-introductions.html)
-
-3\. Introductions often include a lot of mundane content. How can an introduction cultivate motivation (per our recommendations) while still conveying necessary information?
-
-#### [Putting It Together](https://carpentries.github.io/instructor-training/24-practices.html)
-
-4\. Try the "Organize your knowledge" activity! Report back: what did you learn?
+1. What questions do you have about policies and procedures for running a workshop? Where do you think trainees might find this information confusing or unclear?
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/09-Week_9_discussion_questions.md
+++ b/episodes/09-Week_9_discussion_questions.md
@@ -12,12 +12,28 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:::::::::::::::::::::::::::::::::::::::::::::::::: questions
+
+- See discussion questions. 
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::::::::::::::::: prereq
+
 ## Reading:
 
-[Instructor Training: Working With Your Team](https://carpentries.github.io/instructor-training/21-management.html)  
-[Instructor Training: Launches and Landings](https://carpentries.github.io/instructor-training/23-introductions.html)  
-[Instructor Training: Putting It Together](https://carpentries.github.io/instructor-training/24-practices.html)  
-[Pre-Workshop Reading: The Science of Learning](https://carpentries.github.io/instructor-training/files/papers/science-of-learning-2015.pdf)
+From The Carpentries [Instructor Training curriculum](https://carpentries.github.io/instructor-training/instructor/index.html): 
+
+* [Getting Started on Instructor Certification](https://carpentries.github.io/instructor-training/instructor/14-checkout.html)
+* [How we Operate](https://carpentries.github.io/instructor-training/instructor/15-carpentries.html)
+
+From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-seven-research-based-principles-for-smart-teaching/oclc/468969206):
+
+* Conclusion: Applying the Eight Principles to Ourselves (p. 212 - 218)
+* Appendix E: What Are Rubrics and How Can We Use Them? (p. 232 - 241)
+* Appendix F: What Are Learner Checklists and How Can We Use Them? (p. 242 - 243)
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ## Discussion Questions
 

--- a/episodes/10-Week_10_discussion_questions.md
+++ b/episodes/10-Week_10_discussion_questions.md
@@ -27,21 +27,25 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-### *How Learning Works*
+## Discussion Questions
 
-#### Conclusion p. 212-218
+1. What stood out to you from this week's reading? Think of things that made sense in light of your own experience, things you're not convinced of, or questions that you have.
 
-1\. What is one area of teaching skill that you would like to work on? How did you decide on that goal? How could you advise an Instructor to prioritize their
-skill development goals?
+1. What is one area of teaching skill that you would like to work on? How did you decide on that goal? How could you advise an Instructor to prioritize their skill development goals?
 
-## Closing Questions:
+1. Introductions often include a lot of mundane content. How can an introduction cultivate motivation (per our recommendations) while still conveying necessary information?
 
-2\. What questions do you have about your role as a Trainer?
+1. Try the “Organize your knowledge” activity! Report back: what did you learn?
 
-3\. What questions do you have about The Carpentries community?
+1. What questions do you have about your role as a Trainer?
 
-4\. What are your goals as a Trainer?
+1. What questions do you have about The Carpentries community?
 
-5\. What can The Carpentries Core Team and the Trainer community do to support you in your goals?
+1. What are your goals as a Trainer?
+
+1. What can The Carpentries Core Team and the Trainer community do to support you in your goals?
+
+
+
 
 

--- a/episodes/10-Week_10_discussion_questions.md
+++ b/episodes/10-Week_10_discussion_questions.md
@@ -4,11 +4,28 @@ teaching: 5
 exercises: 55
 ---
 
+::::::::::::::::::::::::::::::::::::::: objectives
+
+- objectives
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::::::::::::::::: questions
+
+- See discussion questions. 
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::::::::::::::::: prereq
+
 ## Reading:
 
-Examine [The Carpentries Handbook: Teaching and Hosting](https://docs.carpentries.org/topic_folders/hosts_instructors/index.html)  
-Review [Trainer Guide](https://docs.carpentries.org/topic_folders/instructor_training/trainers_guide.html)  
-*How Learning Works*: Conclusion (p. 212-218)
+From The Carpentries [Instructor Training curriculum](https://carpentries.github.io/instructor-training/instructor/index.html): 
+
+* [Launches and Landings](https://carpentries.github.io/instructor-training/instructor/23-introductions.html)
+* [Putting it Together](https://carpentries.github.io/instructor-training/instructor/24-practices.html)
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ### *How Learning Works*
 


### PR DESCRIPTION
Reorganize reading schedule to integrate relevant sections from the Instructor Training curriculum in the same week as the related chapters in the textbook are read. Reorganize questions to match new reading schedule. Shorten questions where possible. 