### PR TITLE
Reorganize objectives and keypoints

### DIFF
--- a/episodes/02_week2_discussion_questions.md
+++ b/episodes/02_week2_discussion_questions.md
@@ -6,10 +6,10 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Examine relationships between prior knowledge and learning new things.
-- Plan how to use pre-assessment data in preparing to teach Instructor Training.
-- Evaluate the knowledge-organization strategies in terms of ease of use for new Instructors.
-- Apply a concept map to explore concepts of teaching and learning.
+- Examine a past experience with learner motivation in terms of environment, efficacy, and value.
+- Classify learner goals as learning or performance-based.
+- Assess the usefulness of different motivational strategies for Carpentries workshops and trainings.
+
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -33,6 +33,11 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 * [Building Skill with Practice](https://carpentries.github.io/instructor-training/instructor/02-practice-learning.html)
 
+Other: 
+
+* Instructor Training [pre-survey](https://carpentries.github.io/assessment-archives/instructor-training-pre/instructor-training-pre.html) and [post-survey](https://carpentries.github.io/assessment-archives/instructor-training-post/instructor-training-post.html).
+* Workshop [pre-survey](https://carpentries.github.io/assessment-archives/pre-workshop/pre-workshop.html) and [post-survey](https://carpentries.github.io/assessment-archives/instructor-training-post/instructor-training-post.html).
+
 
 :::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -44,7 +49,7 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 1. Give an example of a time from your experience when a learner’s prior knowledge negatively affected their learning. Why do you think prior knowledge had such an impact in this case? Do you think any of the strategies suggested in this chapter might have helped?
 
-1. Read the pre-assessment survey for Instructor Training. How do trainee responses to this survey influence your teaching? 
+1. What information do we have about learners prior knowledge in Carpentries workshops? What information do we have for trainees in Instructor Training? Describe some specific actions Instructors and/or Trainers can take based on this information.
 
 1. Create a concept map (3-5 items with labeled connections) that includes “teaching” and “learning” as concepts. How did you describe the relationship between teaching and learning? What other concepts and relationships did you include? 
 

--- a/episodes/02_week2_discussion_questions.md
+++ b/episodes/02_week2_discussion_questions.md
@@ -67,9 +67,7 @@ Then, share your experience with the process. Did you learn anything from making
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
 - Prior knowledge about teaching strategies varies among trainees in Instructor Training courses. Being attentive to this will improve your impact.
-- Pre-assessment surveys are a critical component of all Carpentries workshops. Help us make them useful for you!
-- Carpentries curriculum templates provide some support for knowledge organization. Instructors can implement additional strategies to help learners create useful connections.
-- Concept maps are a challenging, minimally structured task. They are useful for exploring concepts and relationships prior to teaching because they can make the organization of knowledge more explicit.
+- Pre-assessment surveys are a critical component of all Carpentries workshops and trainings.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/03_week3_discussion_questions.md
+++ b/episodes/03_week3_discussion_questions.md
@@ -59,10 +59,7 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- Learner motivation in Instructor Training can be very different from the motivation we see in workshops.
-- Instructors can influence learner motivation with three 'levers' of value, expected efficacy, and a supportive environment.
-- Carpentries Instructor Training aims to teach several component skills of teaching. However, this does not guarantee that all skills will be actively used. Trainers can prepare trainees to bridge this gap by explicitly discussing application as well as supporting practice and feedback.
-- Trainers experience expert awareness gaps and cognitive overload too!
+- To be added.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/04-week_4_discussion_questions.md
+++ b/episodes/04-week_4_discussion_questions.md
@@ -6,10 +6,10 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Apply Bloom's Taxonomy to adjust the level of a learning objective.
-- Describe how common Carpentries classroom practices provide opportunities for practice and feedback.
-- Evaluate the usefulness of potential sources of feedback for learners.
-- Assess differences between potential feedback coming from learners vs co-Instructors or co-Trainers.
+- Predict the impact of cognitive limitations on both trainees and Trainers in Instructor Training.
+- Compare the challenge of preparing different types of learners (Instructor trainees vs. workshop learners) to transfer skills to usable contexts.
+- Predict challenges posed by expertise awareness gaps in the context of teaching Instructors how to teach.
+- Distinguish challenges related to skill level faced by learners from those faced by Instructors.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/04-week_4_discussion_questions.md
+++ b/episodes/04-week_4_discussion_questions.md
@@ -51,9 +51,7 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- The cognitive level of a task is directly related to the action expected from learners -- not the complexity of the material or the stage of a workflow. Bloom's Taxonomy and associated verb charts are useful tools for evaluating the level of cognition required.
-- Exercises and other classroom practices that keep learners actively engaged can provide many small opportunities for practice and feedback.
-- Co-Instructors and co-Trainers can have a different perspective on instruction compared with learners, but we do not have a systematic way of collecting this feedback. A little advance planning and communication can help ease the awkwardness of sharing between peers.
+- To be added.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/05-week_5_discussion_questions.md
+++ b/episodes/05-week_5_discussion_questions.md
@@ -48,8 +48,7 @@ From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-se
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- The Carpentries Code of Conduct is one of many features that creates a positive classroom climate for Carpentries workshops.
-- Instructor trainees will face challenges as they develop skill in teaching. As in Carpentries workshops, a core goal of our two-day training is to prepare them to encounter and surmount those challenges.
+- To be added.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/05-week_5_discussion_questions.md
+++ b/episodes/05-week_5_discussion_questions.md
@@ -6,10 +6,7 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Explain the impact of The Carpentries Code of Conduct on classroom climate.
-- Predict challenges faced by new Instructors in creating a positive classroom climate and propose possible solutions.
-- Predict challenges faced by new Instructors and learners in transferring metacognitive skills to a new learning process and propose possible solutions.
-- Connect common Carpentries classroom practices with strategies that support metacognition and identify the relationship between them.
+- TBD
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/06-Week_6_discussion_questions.md
+++ b/episodes/06-Week_6_discussion_questions.md
@@ -51,11 +51,7 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- The Carpentries Instructor Training curriculum offers many opportunities to model, as well as to teach, good practices.
-- Skill acquisition models explain challenges faced by learners and Instructors, Instructor trainees and Trainers.
-- Expert teachers may have filled in awareness gaps in subjects they teach, but may still have gaps on the subject of teaching.
-- Going slowly is a challenge that takes constant effort and compromise.
-- There are many approaches and supporting documents available to teach Instructor Training. Many of these are referenced in the Instructor Notes.
+- To be added.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/06-Week_6_discussion_questions.md
+++ b/episodes/06-Week_6_discussion_questions.md
@@ -6,11 +6,9 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Propose one way to support learner interaction early in a workshop even when pressed for time.
-- Apply a concept map to illustrate the importance of explicit connections in knowledge and learning.
-- Distinguish challenges related to skill level faced by learners from those faced by Instructors.
-- Predict challenges posed by expert awareness gaps in the context of teaching Instructors how to teach.
-- Propose a strategy to support Instructor trainees in implementing guidance on pacing in spite of competing priorities related to content and time.
+- Analyze how Carpentries teaching practices align with strategies for designing effective practice opportunities.
+- List two important characteristics of effective feedback.
+- Explain strategies for helping trainees and new Instructors give good feedback.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/07-Week_7_discussion_questions.md
+++ b/episodes/07-Week_7_discussion_questions.md
@@ -36,10 +36,7 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- Convincing trainees to collect feedback is a fundamental goal. Teaching them to use it is the next step.
-- Developing awareness of demotivating scenarios is a fundamental goal. Teaching trainees to cope with them is the next step.
-- Many trainees may have a growth mindset with regard to computational skills and a fixed mindset with regard to teaching skills.
-- New Instructors should start their improvement process with 'low hanging fruit' -- teaching techniques they can easily adopt. For some, this might center on presentation style while for others, it might have more to do with classroom mechanics. Focusing on one thing at a time to improve on can help people evaluate and prioritize their goals as they progress.
+- To be added.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/07-Week_7_discussion_questions.md
+++ b/episodes/07-Week_7_discussion_questions.md
@@ -6,11 +6,7 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Propose approaches to improve the use and usefulness of Carpentries feedback surveys.
-- Suggest ways to prepare trainees to make mistakes in managing learner motivation.
-- Apply concepts related to motivation to the process of learning to teach.
-- Assess completeness and core content of the new episode on Equity, Inclusion, and Accessibility.
-- Propose approaches to support trainees in improving the quality of their feedback.
+- TBD
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/08-Week_8_discussion_questions.md
+++ b/episodes/08-Week_8_discussion_questions.md
@@ -6,10 +6,10 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Suggest ways in which Trainers can support Instructor trainees who may be intimidated or confused by checkout procedures.
-- Identify confusing features of The Carpentries operational landscape.
-- Predict likely characteristics of Instructor trainees, and compare predictions with others.
-- Apply learning objectives to identify checkpoints where objectives are met in a lesson about learning objectives!
+- Explain the impact of The Carpentries Code of Conduct on classroom climate.
+- Predict challenges faced by new Instructors in creating a positive classroom climate and propose possible solutions.
+- Propose one way to support learner interaction early in a workshop even when pressed for time.
+- Identify areas of uncertainty with regard to handling Code of Conduct violations.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/08-Week_8_discussion_questions.md
+++ b/episodes/08-Week_8_discussion_questions.md
@@ -53,11 +53,7 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- Thinking critically about Bloom's Taxonomy is typically beyond the Blooms' level we can expect Instructor trainees to perform at. Examine *your* learning objectives carefully to calibrate your expectations for this episode and meet learners where they are.
-- Instructors are unlikely to face a Code of Conduct violation, but need to know what to do if this occurs. Reassurance of team support and clear instructions on reporting are the most important elements to communicate.
-- Trainees may be intimidated by many elements of checkout. It is important to emphasize that teaching demonstrations are a friendly opportunity to give and receive feedback, not a high-stakes test, and that our Core Team is there to support them with any questions they may have during the checkout process.
-- Participatory live coding keeps participants engaged, generates immediate feedback, and creates opportunities to model a healthy response to error. These features explicitly support learning and motivation.
-- With instructional support, repeated practice and feedback can lead trainees to examine the component skills of teaching.
+- To be added.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/09-Week_9_discussion_questions.md
+++ b/episodes/09-Week_9_discussion_questions.md
@@ -6,9 +6,8 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Identify areas of uncertainty with regard to handling Code of Conduct violations.
-- Recognize conflicts between demands for introductory content and goals for motivating learners, and propose an approach that addresses both.
-- Apply concept mapping to organize content from the Instructor Training curriculum.
+- Suggest ways in which Trainers can support Instructor trainees who may be intimidated or confused by checkout procedures.
+- Identify confusing features of The Carpentries operational landscape.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/09-Week_9_discussion_questions.md
+++ b/episodes/09-Week_9_discussion_questions.md
@@ -44,8 +44,7 @@ From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-se
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- Introducing a workshop has an outsized impact on the overall experience of the workshop. In addition to emphasizing preparation, it can be helpful to encourage trainees to think about this as a teaching challenge.
-- At the end of the workshop, we ask our trainees to take some time to organize some of the information they have learned. This is also a useful exercise to practice when preparing to teach the workshop!
+- To be added.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/10-Week_10_discussion_questions.md
+++ b/episodes/10-Week_10_discussion_questions.md
@@ -6,7 +6,8 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- objectives
+- Apply concept mapping to organize content from the Instructor Training curriculum.
+- More TBD.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/10-Week_10_discussion_questions.md
+++ b/episodes/10-Week_10_discussion_questions.md
@@ -46,7 +46,11 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 1. What can The Carpentries Core Team and the Trainer community do to support you in your goals?
 
+:::::::::::::::::::::::::::::::::::::::: keypoints
 
+- To be added.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
 


### PR DESCRIPTION
- Reorders learning objectives to match new order of readings.
- Rephrases some learning objectives for clarity and simplicity of language. 
- Updates keypoints for episodes 1-2, removes keypoints for episodes 3-10. To be added at least a week in advance of each classes reading. 
- Moves pre and post workshop and pre and post instructor training surveys to week 2, to go along with knowledge organisation discussion. 