### PR TITLE
correct link to post-workshop survey

### DIFF
--- a/episodes/02_week2_discussion_questions.md
+++ b/episodes/02_week2_discussion_questions.md
@@ -36,7 +36,7 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 Other: 
 
 * Instructor Training [pre-survey](https://carpentries.github.io/assessment-archives/instructor-training-pre/instructor-training-pre.html) and [post-survey](https://carpentries.github.io/assessment-archives/instructor-training-post/instructor-training-post.html).
-* Workshop [pre-survey](https://carpentries.github.io/assessment-archives/pre-workshop/pre-workshop.html) and [post-survey](https://carpentries.github.io/assessment-archives/instructor-training-post/instructor-training-post.html).
+* Workshop [pre-survey](https://carpentries.github.io/assessment-archives/pre-workshop/pre-workshop.html) and [post-survey](https://carpentries.github.io/assessment-archives/post-workshop/post-workshop.html).
 
 
 :::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
Link was not the right one, and was doubled-up from above. Llikely was a copy-paste mistake.