### PR TITLE
draft some missing objectives and key points

### DIFF
--- a/episodes/03_week3_discussion_questions.md
+++ b/episodes/03_week3_discussion_questions.md
@@ -59,7 +59,8 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- To be added.
+- We expect trainees to have diverse motivations for joining Instructor Training.
+- Although Carpentries workshops and trainings are short, there are many strategies that we can employ to keep learners and trainees motivated.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/04-week_4_discussion_questions.md
+++ b/episodes/04-week_4_discussion_questions.md
@@ -51,7 +51,8 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- To be added.
+- To be effective Trainers, we must be aware of our own expertise in teaching.
+- Teaching Instructor Training creates a lot of cognitive load! The Trainer community has developed several strategies to help manage this load during training events.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/04-week_4_discussion_questions.md
+++ b/episodes/04-week_4_discussion_questions.md
@@ -52,7 +52,7 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
 - To be effective Trainers, we must be aware of our own expertise in teaching.
-- Teaching Instructor Training creates a lot of cognitive load! The Trainer community has developed several strategies to help manage this load during training events.
+- Teaching Instructor Training creates a lot of cognitive load! The Instructor Trainer community has developed several strategies to help manage this load during training events.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/04-week_4_discussion_questions.md
+++ b/episodes/04-week_4_discussion_questions.md
@@ -51,7 +51,7 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- To be effective Trainers, we must be aware of our own expertise in teaching.
+- To be effective Instructor Trainers, we must be aware of our own expertise in teaching.
 - Teaching Instructor Training creates a lot of cognitive load! The Instructor Trainer community has developed several strategies to help manage this load during training events.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/05-week_5_discussion_questions.md
+++ b/episodes/05-week_5_discussion_questions.md
@@ -6,7 +6,11 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- TBD
+- Describe the target audience of Instructor Training.
+- Discuss whether a learning objective fits the audience and content of a lesson/curriculum.
+- Identify strategies to handle Code of Conduct incidents during an Instructor Training event.
+- Explain the value of "never teaching alone".
+
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/06-Week_6_discussion_questions.md
+++ b/episodes/06-Week_6_discussion_questions.md
@@ -51,7 +51,8 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- To be added.
+- Feedback is an essential part of Carpentries workshops and Instructor Training. Trainees often need guidance on how to invite, give, and receive good feedback.
+- The ways that a team of Instructors and Helpers manages the learning environment of a workshop can have a profound effect on how much effective feedback learners receive. Instructor Training should make trainees aware of this and give them strategies to maximise their impact. 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/09-Week_9_discussion_questions.md
+++ b/episodes/09-Week_9_discussion_questions.md
@@ -45,7 +45,7 @@ From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-se
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
 - The Carpentries can appear large and complicated to newcomers, and Instructor Training may be a trainee's first encounter with the community. 
-- Trainers may need to overcome their own expert awareness gaps in relation to The Carpentries while teaching Instructor Training.
+- Instructor Trainers may need to overcome their own expert awareness gaps in relation to The Carpentries while teaching Instructor Training.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/09-Week_9_discussion_questions.md
+++ b/episodes/09-Week_9_discussion_questions.md
@@ -44,7 +44,8 @@ From [*How Learning Works*](https://www.worldcat.org/title/how-learning-works-se
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- To be added.
+- The Carpentries can appear large and complicated to newcomers, and Instructor Training may be a trainee's first encounter with the community. 
+- Trainers may need to overcome their own expert awareness gaps in relation to The Carpentries while teaching Instructor Training.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/10-Week_10_discussion_questions.md
+++ b/episodes/10-Week_10_discussion_questions.md
@@ -6,7 +6,7 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Explain the importance of a Trainer's introduction to the success of Instructor Training.
+- Explain the importance of an Instructor Trainer's introduction to the success of Instructor Training.
 - Apply concept mapping to organize content from the Instructor Training curriculum.
 - Reflect on what has been learned during this training.
 - Identify goals for the further development of teaching skill.
@@ -50,8 +50,8 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- Although Trainers are considered experts in teaching within The Carpentries community, we need to keep practising our skills to build and maintain them.
-- Trainers are supported by other members of the Trainer community and The Carpentries Core Team.
+- Although Instructor Trainers are considered experts in teaching within The Carpentries community, we need to keep practising our skills to build and maintain them.
+- Instructor Trainers are supported by each other and by The Carpentries Core Team.
 - Teaching Instructor Training can be demanding but it is also very rewarding and often a lot of fun!
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/10-Week_10_discussion_questions.md
+++ b/episodes/10-Week_10_discussion_questions.md
@@ -6,8 +6,10 @@ exercises: 55
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
+- Explain the importance of a Trainer's introduction to the success of Instructor Training.
 - Apply concept mapping to organize content from the Instructor Training curriculum.
-- More TBD.
+- Reflect on what has been learned during this training.
+- Identify goals for the further development of teaching skill.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -48,7 +50,9 @@ From The Carpentries [Instructor Training curriculum](https://carpentries.github
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- To be added.
+- Although Trainers are considered experts in teaching within The Carpentries community, we need to keep practising our skills to build and maintain them.
+- Trainers are supported by other members of the Trainer community and The Carpentries Core Team.
+- Teaching Instructor Training can be demanding but it is also very rewarding and often a lot of fun!
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
After reading a comment (presumably from @ErinBecker) in the notes of a recent Maintainers meeting, I wanted to have a go at drafting the remaining LOs and key points that were missing from this curriculum. Admittedly, it has been some time since I participated in Instructor Trainer Training, so some of these may miss the mark. I will not be offended if you make significant edits or even throw them out altogether! 😆 

Please note also @vasilislenis' PR #71, which you may want to review/merge before tackling this one. 